### PR TITLE
Refactor Local Cache

### DIFF
--- a/raven/cli.py
+++ b/raven/cli.py
@@ -6,7 +6,7 @@ Main CLI entry point for raven.
 """
 
 import click
-import raven.utils.local_cache as local_cache
+from raven.utils.local_cache import global_cache
 from raven.train.commands import train
 from raven.data.commands import data
 
@@ -20,7 +20,7 @@ def cli():
 def clean():
     """ Cleans locally saved raven cache files.
     """
-    local_cache.clean() 
+    global_cache.clean() 
 
 cli.add_command(train)
 cli.add_command(data)

--- a/raven/data/commands.py
+++ b/raven/data/commands.py
@@ -10,6 +10,7 @@ import click
 from colorama import init, Fore
 from halo import Halo
 from raven.utils.dataset import get_dataset_names, get_dataset_metadata
+from raven.utils.question import cli_spinner
 
 init()
 
@@ -43,20 +44,15 @@ def list(detailed: bool):
     Args:
         detailed: T/F show detailed view
     """
-    spinner = Halo(text="Finding datasets on S3...", text_color="magenta")
-    spinner.start()
-    dataset_names = get_dataset_names()
-    spinner.succeed(text=spinner.text + "Complete.")
+    dataset_names = cli_spinner("Finding datasets on S3...", get_dataset_names)
 
-    if not detailed:
-        for name in dataset_names:
-            click.echo(name)
+    if detailed:
+        detailed_info = cli_spinner("Downloading dataset metadata from S3...", _get_detailed_dataset_info, dataset_names)
+        pydoc.pager(detailed_info)      
         return
-    spinner = Halo(text="Downloading dataset metadata from S3...", text_color="magenta")
-    spinner.start()
-    detailed_info = _get_detailed_dataset_info(dataset_names)
-    spinner.succeed(text=spinner.text + "Complete.")
-    pydoc.pager(detailed_info)      
+        
+    for name in dataset_names:
+        click.echo(name)
 
 @data.command()
 @click.argument('dataset_name')
@@ -66,10 +62,7 @@ def inspect(dataset_name: str):
     Args:
         dataset_name: string name of the dataset to inspect
     """
-    spinner = Halo(text="Downloading dataset metadata from S3...", text_color="magenta")
-    spinner.start()
-    metadata = get_dataset_metadata(dataset_name)
-    spinner.succeed(text=spinner.text + 'Complete.')
+    metadata = cli_spinner("Downloading dataset metadata from S3...", get_dataset_metadata, dataset_name)
     click.echo(_stringify_metadata(metadata, colored=True))
 
 

--- a/raven/utils/dataset.py
+++ b/raven/utils/dataset.py
@@ -9,14 +9,15 @@ import os
 import json
 from pathlib import Path
 import boto3
-import raven.utils.local_cache as local_cache
+from raven.utils.local_cache import LocalCache, global_cache
 from raven.data.interfaces import Dataset
 
 S3 = boto3.resource('s3')
 DATASET_BUCKET = S3.Bucket('skr-datasets-test')
 
-# path within local cache for datasets
-DATASETS_PATH = local_cache.RAVEN_LOCAL_STORAGE_PATH / Path('datasets')
+# LocalCache within local cache for datasets
+dataset_cache = LocalCache(path=global_cache.path / Path('datasets'))
+
 
 ### PUBLIC METHODS ###
 def get_dataset_names():
@@ -43,7 +44,7 @@ def get_dataset_metadata(name: str, no_check=False):
     """
     if not no_check:
         _ensure_metadata(name)
-    return json.load(open(DATASETS_PATH / Path(name) / 'metadata.json'))
+    return json.load(open(dataset_cache.path / Path(name) / 'metadata.json'))
 
 def get_dataset(name: str):
     """Retrives a dataset. Downloads from S3 if necessary.
@@ -77,12 +78,12 @@ def _ensure_metadata(name: str):
     Args:
         name (str): name of dataset
     """
-    metadata_path = DATASETS_PATH / Path(name) / 'metadata.json'
-    if not local_cache.subpath_exists(metadata_path):
-        local_cache.ensure_exists()
-        local_cache.ensure_subpath_exists(_to_dataset_dir(name))
+    metadata_path = Path(name) / 'metadata.json'
+    if not dataset_cache.subpath_exists(metadata_path):
+        dataset_cache.ensure_subpath_exists(name)
         metadata_key = f'{name}/metadata.json'
-        DATASET_BUCKET.download_file(metadata_key, str(metadata_path))
+        metadata_absolute_path = dataset_cache.path / metadata_path
+        DATASET_BUCKET.download_file(metadata_key, str(metadata_absolute_path))
 
 def _ensure_dataset(name: str):
     """Ensures dataset exists.
@@ -90,18 +91,9 @@ def _ensure_dataset(name: str):
     Args:
         name (str): name of dataset
     """
-    # ensure local cache exists
-    local_cache.ensure_exists()
-    # loop through all objects in the bucket
     for obj in DATASET_BUCKET.objects.filter(Prefix = name):
-        # add `datasets/` prefix to object key
-        local_key = _to_dataset_dir(obj.key)
-        if not local_cache.subpath_exists(local_key):
-            # get subpath of object
-            subpath = os.path.dirname(local_key)
-            # ensure destination of object exists
-            local_cache.ensure_subpath_exists(subpath)
-            # create final absolute storage path
-            storage_path = DATASETS_PATH / Path(obj.key)
-            # actually download file to destination
+        if not dataset_cache.subpath_exists(obj.key):
+            subpath = os.path.dirname(obj.key)
+            dataset_cache.ensure_subpath_exists(subpath)
+            storage_path = dataset_cache.path / Path(obj.key)
             DATASET_BUCKET.download_file(obj.key, str(storage_path))

--- a/raven/utils/local_cache.py
+++ b/raven/utils/local_cache.py
@@ -10,6 +10,7 @@ import shutil
 import click
 from pathlib import Path
 
+# local cache root path for raven application
 RAVEN_LOCAL_STORAGE_PATH = Path(os.path.expanduser('~/.raven-ml'))
 
 class LocalCache(object):

--- a/raven/utils/local_cache.py
+++ b/raven/utils/local_cache.py
@@ -12,46 +12,109 @@ from pathlib import Path
 
 RAVEN_LOCAL_STORAGE_PATH = Path(os.path.expanduser('~/.raven-ml'))
 
-def _create():
-    """Makes the local storage cache for raven.
+class LocalCache(object):
+
+    def __init__(self, path=RAVEN_LOCAL_STORAGE_PATH):
+        self._path = path
+        self.ensure_exists()
+
+    def exists(self):
+        """Checks if local storage cache exists on the machine.
+        """
+        return os.path.exists(self.path)
+        
+    def ensure_exists(self):
+        """Ensures that the local storage cache exists on the machine.
+        """
+        if not self.exists():
+            self._create()
+
+    def subpath_exists(self, subpath: str):
+        """Checks if a subpath within the local storage_cache exists.
+        """
+        return os.path.exists(self.path / Path(subpath))
+
+    def ensure_subpath_exists(self, subpath: str):
+        """Ensures the subpath exists in the local storage cache.
+        """
+        if not self.subpath_exists(subpath):
+            self._make_subpath(subpath)
+        
+    def clean(self):
+        """Cleans local storage cache.
+        """
+        try:
+            shutil.rmtree(self.path)
+        except FileNotFoundError:
+            click.echo('Nothing to clean.')
     
-    Not for external use (use ensure_exists() instead)
-    """
-    os.mkdir(RAVEN_LOCAL_STORAGE_PATH)
-
-def exists():
-    """Checks if local storage cache exists on the machine.
-    """
-    return os.path.exists(RAVEN_LOCAL_STORAGE_PATH)
-
-def ensure_exists():
-    """Ensures that the local storage cache exists on the machine.
-    """
-    if not exists():
-        _create()
-
-def subpath_exists(subpath: str):
-    """Checks if a subpath within the local storage_cache exists.
-    """
-    return os.path.exists(RAVEN_LOCAL_STORAGE_PATH / Path(subpath))
-
-def _make_subpath(subpath):
-    """Creates a subpath within the local storage cache.
-
-    Not for external use (use ensure_subpath_exists() instead)
-    """
-    os.makedirs(RAVEN_LOCAL_STORAGE_PATH / Path (subpath))
-
-def ensure_subpath_exists(subpath: str):
-    """Ensures the subpath exists in the local storage cache.
-    """
-    if not subpath_exists(subpath):
-        _make_subpath(subpath)
+    @property
+    def path(self):
+        return self._path
     
-def clean():
-    """Cleans local storage cache.
-    """
-    try:
-        shutil.rmtree(RAVEN_LOCAL_STORAGE_PATH)
-    except FileNotFoundError:
-        click.echo('Nothing to clean.')
+    @path.setter
+    def path(self, path):
+        self._path = path
+
+    def _create(self):
+        """Makes the local storage cache for raven.
+        
+        Not for external use (use ensure_exists() instead)
+        """
+        os.makedirs(self.path)
+
+    def _make_subpath(self, subpath):
+        """Creates a subpath within the local storage cache.
+
+        Not for external use (use ensure_subpath_exists() instead)
+        """
+        os.makedirs(self.path / Path(subpath))
+    
+global_cache = LocalCache()
+    
+# #### YUP
+
+# def exists():
+#     """Checks if local storage cache exists on the machine.
+#     """
+#     return os.path.exists(RAVEN_LOCAL_STORAGE_PATH)
+    
+# def ensure_exists():
+#     """Ensures that the local storage cache exists on the machine.
+#     """
+#     if not exists():
+#         _create()
+
+# def subpath_exists(subpath: str):
+#     """Checks if a subpath within the local storage_cache exists.
+#     """
+#     return os.path.exists(RAVEN_LOCAL_STORAGE_PATH / Path(subpath))
+
+# def ensure_subpath_exists(subpath: str):
+#     """Ensures the subpath exists in the local storage cache.
+#     """
+#     if not subpath_exists(subpath):
+#         _make_subpath(subpath)
+    
+# def clean():
+#     """Cleans local storage cache.
+#     """
+#     try:
+#         shutil.rmtree(RAVEN_LOCAL_STORAGE_PATH)
+#     except FileNotFoundError:
+#         click.echo('Nothing to clean.')
+
+# def _create():
+#     """Makes the local storage cache for raven.
+    
+#     Not for external use (use ensure_exists() instead)
+#     """
+#     os.mkdir(RAVEN_LOCAL_STORAGE_PATH)
+
+# def _make_subpath(subpath):
+#     """Creates a subpath within the local storage cache.
+
+#     Not for external use (use ensure_subpath_exists() instead)
+#     """
+
+#     os.makedirs(RAVEN_LOCAL_STORAGE_PATH / Path(subpath), exist_ok=True)

--- a/raven/utils/local_cache.py
+++ b/raven/utils/local_cache.py
@@ -13,6 +13,15 @@ from pathlib import Path
 RAVEN_LOCAL_STORAGE_PATH = Path(os.path.expanduser('~/.raven-ml'))
 
 class LocalCache(object):
+    """Represents a local storage cache. Provides functions for
+    ensuring the cache exists and making subpaths within it.
+
+    Args:
+        path (Path): Absolute path in filesystem to serve as root of the local cache.
+    
+    Attributes:
+        path (Path): Absolute path in filesystem to root of the local cache.
+    """
 
     def __init__(self, path=RAVEN_LOCAL_STORAGE_PATH):
         self._path = path
@@ -20,6 +29,9 @@ class LocalCache(object):
 
     def exists(self):
         """Checks if local storage cache exists on the machine.
+        
+        Returns:
+            bool: true if local cache exists, false if not
         """
         return os.path.exists(self.path)
         
@@ -31,11 +43,20 @@ class LocalCache(object):
 
     def subpath_exists(self, subpath: str):
         """Checks if a subpath within the local storage_cache exists.
+        
+        Args:
+            subpath (str): desired subpath (i.e 'datasets/my_dataset')
+        
+        Returns:
+            bool: true if subpath exists, false if not
         """
         return os.path.exists(self.path / Path(subpath))
 
     def ensure_subpath_exists(self, subpath: str):
         """Ensures the subpath exists in the local storage cache.
+        
+        Args:
+            subpath (str): desired subpath (i.e 'datasets/my_dataset')
         """
         if not self.subpath_exists(subpath):
             self._make_subpath(subpath)
@@ -70,51 +91,13 @@ class LocalCache(object):
         """
         os.makedirs(self.path / Path(subpath))
     
+# importable global cache, should be used wherever possible
+#
+# Example use for datasets:
+#
+# from pathlib import Path
+# from raven.utils.local_cache import LocalCache, global_cache
+#
+# dataset_cache = LocalCache(path=global_path.path / Path('datasets'))
+#
 global_cache = LocalCache()
-    
-# #### YUP
-
-# def exists():
-#     """Checks if local storage cache exists on the machine.
-#     """
-#     return os.path.exists(RAVEN_LOCAL_STORAGE_PATH)
-    
-# def ensure_exists():
-#     """Ensures that the local storage cache exists on the machine.
-#     """
-#     if not exists():
-#         _create()
-
-# def subpath_exists(subpath: str):
-#     """Checks if a subpath within the local storage_cache exists.
-#     """
-#     return os.path.exists(RAVEN_LOCAL_STORAGE_PATH / Path(subpath))
-
-# def ensure_subpath_exists(subpath: str):
-#     """Ensures the subpath exists in the local storage cache.
-#     """
-#     if not subpath_exists(subpath):
-#         _make_subpath(subpath)
-    
-# def clean():
-#     """Cleans local storage cache.
-#     """
-#     try:
-#         shutil.rmtree(RAVEN_LOCAL_STORAGE_PATH)
-#     except FileNotFoundError:
-#         click.echo('Nothing to clean.')
-
-# def _create():
-#     """Makes the local storage cache for raven.
-    
-#     Not for external use (use ensure_exists() instead)
-#     """
-#     os.mkdir(RAVEN_LOCAL_STORAGE_PATH)
-
-# def _make_subpath(subpath):
-#     """Creates a subpath within the local storage cache.
-
-#     Not for external use (use ensure_subpath_exists() instead)
-#     """
-
-#     os.makedirs(RAVEN_LOCAL_STORAGE_PATH / Path(subpath), exist_ok=True)


### PR DESCRIPTION
### Overview
Refactored local cache to be an object. This allows you to make a new local cache object whose root is within the local cache itself for easier access. Example below:

```python
from pathlib import Path
from raven.utils.local_cache import LocalCache, global_cache

dataset_cache = LocalCache(path=global_cache.path / Path('datasets'))
```
`global_cache` is a LocalCache object whose path is the root of the raven application local cache (~/.raven-ml) and is importable from `local_cache`. `dataset_cache` now has a root path of `~/.raven-ml/datasets`, so that when you are working with datasets you do not have to worry about adding 'datasets' to the front of all your paths.

Also refactored data commands to use the `cli_spinner` helper function.