### PR TITLE
Centralize no user option | Add no user option to config command | Small Fixes

### DIFF
--- a/ravenml/cli.py
+++ b/ravenml/cli.py
@@ -10,6 +10,13 @@ from ravenml.utils.local_cache import global_cache
 from ravenml.train.commands import train
 from ravenml.data.commands import data
 from ravenml.config.commands import config
+from ravenml.utils.config import get_config, update_config
+
+## OPTIONS
+clean_all_opt = click.option(
+    '-a', '--all', is_flag=True,
+    help='Disable Inquirer prompts and use flags instead.'
+)
 
 @click.group()
 def cli():
@@ -18,10 +25,19 @@ def cli():
     pass
     
 @cli.command()
-def clean():
+@clean_all_opt
+def clean(all):
     """ Cleans locally saved ravenml cache files.
     """
-    global_cache.clean() 
+    if all:
+        global_cache.clean() 
+    else:
+        try:
+            config = get_config()
+            global_cache.clean()
+            update_config(config)
+        except (ValueError, FileNotFoundError):
+            global_cache.clean()
 
 cli.add_command(train)
 cli.add_command(data)

--- a/ravenml/cli.py
+++ b/ravenml/cli.py
@@ -15,7 +15,7 @@ from ravenml.utils.config import get_config, update_config
 ## OPTIONS
 clean_all_opt = click.option(
     '-a', '--all', is_flag=True,
-    help='Disable Inquirer prompts and use flags instead.'
+    help='Clear all cache contents, including saved ravenML configuration.'
 )
 
 @click.group()

--- a/ravenml/cli.py
+++ b/ravenml/cli.py
@@ -6,11 +6,14 @@ Main CLI entry point for ravenml.
 """
 
 import click
+from colorama import init, Fore
 from ravenml.utils.local_cache import global_cache
 from ravenml.train.commands import train
 from ravenml.data.commands import data
 from ravenml.config.commands import config
 from ravenml.utils.config import get_config, update_config
+
+init()
 
 ## OPTIONS
 clean_all_opt = click.option(
@@ -30,14 +33,19 @@ def clean(all):
     """ Cleans locally saved ravenml cache files.
     """
     if all:
-        global_cache.clean() 
+        if not global_cache.clean():
+            click.echo(Fore.RED + 'No cache to clean.')
     else:
         try:
             config = get_config()
             global_cache.clean()
             update_config(config)
-        except (ValueError, FileNotFoundError):
+        except ValueError:
+            click.echo(Fore.RED + 'Bad configuration file. Deleting alongside cache.') 
             global_cache.clean()
+        except FileNotFoundError:
+            if not global_cache.clean():
+                click.echo(Fore.RED + 'No cache to clean.')
 
 cli.add_command(train)
 cli.add_command(data)

--- a/ravenml/options.py
+++ b/ravenml/options.py
@@ -1,0 +1,34 @@
+
+"""
+Author(s):      Carson Schubert (carson.schubert14@gmail.com)  
+Date Created:   4/11/2019
+
+Standard options which should be used by ravenml plugins.
+"""
+
+import click
+
+### HELPERS/CALLBACKS ###
+def no_user_callback(ctx, param, value):
+    # set in context
+    ctx.obj = {}
+    ctx.obj['NO_USER'] = value
+    # if we are in no_user mode, check all required arguments are there
+    if value:
+        for arg, value in ctx.params.items():
+            if value is None:
+                ctx.exit('You must supply the --%s argument when using --no-user!'%arg)
+
+# NOTE: Any option intended to be used alongside the no_user_opt on a command
+# must have their is_eager flag set to TRUE for no_user_opt to work properly
+
+### OPTIONS ###
+"""Flag to determine if the command should run in user mode.
+"""
+no_user_opt = click.option(
+    '--no-user', is_flag=True, callback=no_user_callback, expose_value=False,
+    help='Disable Inquirer prompts and use flags instead.'
+)
+
+
+### PASS DECORATORS ###

--- a/ravenml/tests/config_command_test.py
+++ b/ravenml/tests/config_command_test.py
@@ -12,8 +12,10 @@ from pathlib import Path
 from shutil import copyfile
 from click.testing import CliRunner
 from ravenml.config.commands import show, update
+from ravenml.cli import clean
 from ravenml.utils.local_cache import global_cache
 from ravenml.utils.dataset import dataset_cache
+from ravenml.utils.config import get_config, update_config
 
 ### SETUP ###
 runner = CliRunner()
@@ -38,6 +40,9 @@ def teardown_module():
     global_cache.clean()
     
 
+# NOTE: there are no automated tests for prompt behavior of commands, as prompt-toolkit
+# does not deal nicley with stdin not being an actual terminal (as pytest does it)
+
 ### TESTS ###
 def test_show():
     """ Tests the show subcommand.
@@ -49,6 +54,28 @@ def test_show():
     sub = ansi_escape.sub('', result.output)
     assert sub == data
 
-# def test_update():
-#     result = runner.invoke(update, input='\r\r')
-#     assert result.exit_code == 0
+def test_update():
+    """Tests the update subcommand in no user mode.
+    """
+    result = runner.invoke(update, ['--no-user', '-d', 'test_data_buck', '-a', 'test_art_buck'])
+    assert result.exit_code == 0
+    with open(test_data_dir / Path('config_update_contents.txt'), 'r') as myfile:
+        data = myfile.read()
+    with open(global_cache.path / Path('config.yml'), 'r') as myfile:
+        config_contents = myfile.read()
+    assert config_contents == data
+    
+def test_update_no_config():
+    """Basically the same as test_update, except we clean the existing configuration
+    file away before calling it. Ensures the command properly deals with this scanario.
+    """
+    config = get_config()
+    global_cache.clean()
+    result = runner.invoke(update, ['--no-user', '-d', 'test_data_buck', '-a', 'test_art_buck'])
+    assert result.exit_code == 0
+    with open(test_data_dir / Path('config_update_contents.txt'), 'r') as myfile:
+        data = myfile.read()
+    with open(global_cache.path / Path('config.yml'), 'r') as myfile:
+        config_contents = myfile.read()
+    assert config_contents == data
+    update_config(config)

--- a/ravenml/tests/data/config_update_contents.txt
+++ b/ravenml/tests/data/config_update_contents.txt
@@ -1,0 +1,2 @@
+artifact_bucket_name: test_art_buck
+dataset_bucket_name: test_data_buck

--- a/ravenml/tests/data_command_test.py
+++ b/ravenml/tests/data_command_test.py
@@ -50,6 +50,9 @@ def teardown_module():
     global_cache.clean()
     mock.stop()    
     
+    
+# NOTE: there are no automated tests for prompt behavior of commands, as prompt-toolkit
+# does not deal nicley with stdin not being an actual terminal (as pytest does it)
 
 ### TESTS ###
 def test_list_no_flags():

--- a/ravenml/tests/local_cache_test.py
+++ b/ravenml/tests/local_cache_test.py
@@ -1,0 +1,52 @@
+"""
+Author(s):      Carson Schubert (carson.schubert14@gmail.com)
+Date Created:   04/11/19
+
+Tests the ravenml local_cache module.
+
+NOTE: If this test fails, it may cause cascades of failures in other tests.
+"""
+
+import pytest
+import os
+import re
+from pathlib import Path
+from click.testing import CliRunner
+from ravenml.cli import cli
+from ravenml.utils.local_cache import global_cache
+
+### SETUP ###
+runner = CliRunner()
+test_dir = os.path.dirname(__file__)
+test_data_dir = test_dir / Path('data')
+ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]')
+
+def setup_module():
+    """ Sets up the module for testing.
+    """
+    # alter global and dataset cache objects used throughout ravenml for local caching
+    # global_cache.path = test_dir / Path('.testing')
+    # global_cache.ensure_exists()
+    # dataset_cache.path = global_cache.path / Path('datasets')
+    
+    # copy config file from test data into temporary testing cache
+    # copyfile(test_data_dir / Path('config.yml'), global_cache.path / Path('config.yml'))
+
+def teardown_module():
+    """ Tears down the module after testing.
+    """
+    # global_cache.clean()
+    
+
+# NOTE: there are no automated tests for prompt behavior of commands, as prompt-toolkit
+# does not deal nicley with stdin not being an actual terminal (as pytest does it)
+
+### TESTS ###
+def test_no_leaky_cache_creation():
+    """Assues that simply running `ravenml` on the command line does not 
+    create the local cache. Can indicate that somewhere a piece of code is 
+    ensuring the existence of the local cache on import, which we DO NOT want.
+    """
+    result = runner.invoke(cli)
+    assert result.exit_code == 0
+    assert not os.path.exists(global_cache.path)

--- a/ravenml/train/commands.py
+++ b/ravenml/train/commands.py
@@ -11,24 +11,9 @@ from click_plugins import with_plugins
 from ravenml.train.interfaces import TrainInput, TrainOutput
 from ravenml.utils.dataset import get_dataset_names, get_dataset
 from ravenml.utils.question import cli_spinner
+from ravenml.options import no_user_opt
     
 ### OPTIONS ###
-def no_user_callback(ctx, param, value):
-    # set in context
-    ctx.obj = {}
-    ctx.obj['NO_USER'] = value
-    # if we are in no_user mode, check all required arguments are there
-    if value:
-        for arg, value in ctx.params.items():
-            if value is None:
-                ctx.exit('You must supply the --%s argument when using --no-user!'%arg)
-    
-no_user_opt = click.option(
-    '--no-user', is_flag=True, callback=no_user_callback, expose_value=False,
-    help='Disable Inquirer prompts and use flags instead.'
-)
-
-# these commands must be eager so their values are available in the no_user_opt callback
 # dataset_opt = click.option(
 #     '-d', '--dataset', 'dataset', type=click.Choice(get_dataset_names()), is_eager=True,
 #     help='Dataset to use for training.'

--- a/ravenml/train/options.py
+++ b/ravenml/train/options.py
@@ -8,12 +8,11 @@ Standard options which should be used by ravenml training plugins.
 import click
 from ravenml.train.interfaces import TrainInput
 
-### HELPERS ###
+### HELPERS/CALLBACKS ###
 
 
-### TRAIN CONTROL OPTIONS ###
-"""
-Flag to determine if K-Fold Cross Validation will be used in training.
+### OPTIONS ###
+"""Flag to determine if K-Fold Cross Validation will be used in training.
 """
 kfold_opt = click.option(
     '-k', '--kfold', is_flag=True, help='Perform kfold cross validation training.'

--- a/ravenml/utils/config.py
+++ b/ravenml/utils/config.py
@@ -45,5 +45,7 @@ def update_config(config: dict):
     Args:
         config (dict): new configuration as a dict
     """
+    # ensure our output location actually exists
+    global_cache.ensure_exists()
     with open(global_cache.path / Path('config.yml'), 'w') as outfile:
         yaml.dump(config, outfile, default_flow_style=False)

--- a/ravenml/utils/dataset.py
+++ b/ravenml/utils/dataset.py
@@ -86,8 +86,9 @@ def _ensure_dataset(name: str):
     config = get_config()
     DATASET_BUCKET = S3.Bucket(config['dataset_bucket_name'])
     for obj in DATASET_BUCKET.objects.filter(Prefix = name):
-        if not dataset_cache.subpath_exists(obj.key):
-            subpath = os.path.dirname(obj.key)
-            dataset_cache.ensure_subpath_exists(subpath)
-            storage_path = dataset_cache.path / Path(obj.key)
-            DATASET_BUCKET.download_file(obj.key, str(storage_path))
+        if obj.key[-1] != '/':
+            if not dataset_cache.subpath_exists(obj.key):
+                subpath = os.path.dirname(obj.key)
+                dataset_cache.ensure_subpath_exists(subpath)
+                storage_path = dataset_cache.path / Path(obj.key)
+                DATASET_BUCKET.download_file(obj.key, str(storage_path))

--- a/ravenml/utils/local_cache.py
+++ b/ravenml/utils/local_cache.py
@@ -26,7 +26,6 @@ class LocalCache(object):
 
     def __init__(self, path=RAVENML_LOCAL_STORAGE_PATH):
         self._path = path
-        self.ensure_exists()
 
     def exists(self):
         """Checks if local storage cache exists on the machine.

--- a/ravenml/utils/local_cache.py
+++ b/ravenml/utils/local_cache.py
@@ -61,7 +61,7 @@ class LocalCache(object):
         """
         if not self.subpath_exists(subpath):
             self._make_subpath(subpath)
-        
+
     def clean(self):
         """Cleans local storage cache.
         """

--- a/ravenml/utils/local_cache.py
+++ b/ravenml/utils/local_cache.py
@@ -64,11 +64,15 @@ class LocalCache(object):
 
     def clean(self):
         """Cleans local storage cache.
+        
+        Returns:
+            bool: True if successfully removed cache, false if no cache found for removal
         """
         try:
             shutil.rmtree(self.path)
+            return True
         except FileNotFoundError:
-            click.echo('Nothing to clean.')
+            return False
     
     @property
     def path(self):


### PR DESCRIPTION
### Overview
Main progress:

- Centralized no_user_opt and its callback to `ravenml/options.py`.
- Added no_user_opt functionality to `config update` command
- Now gives better feedback on `ravenml clean` command
- `ravenml clean` now leaves the configuration file unaffected by default - can use `ravenml clean --all` to clear the entire local cache, including configuration
- Added check when downloading datasets for S3 folder objects that can occur when a dataset is manually created in the S3 console
- More useful return on LocalCache.clean function (true if successful, false if no local cache found to delete)
- Add testing module for local_cache with specific test for leaky global/local cache creation that can occur if `ensure_exists()` is called on a LocalCache on import rather than as necessary by commands.