### PR TITLE
Implement lazy plugin loading

### DIFF
--- a/ravenml/data/commands.py
+++ b/ravenml/data/commands.py
@@ -12,6 +12,7 @@ from click_plugins import with_plugins
 from colorama import Fore
 from ravenml.utils.imageset import get_imageset_names, get_imageset_metadata
 from ravenml.utils.dataset import get_dataset_names, get_dataset_metadata
+from ravenml.utils.plugins import LazyPluginGroup
 from ravenml.utils.question import cli_spinner
 
 # metedata fields to exclude when printing metadata to the user 
@@ -57,8 +58,7 @@ def process_result(ctx: click.Context, result):
 
 ## Dataset Creation Commands ##
 # TODO: determine interfaces for this command
-@with_plugins(iter_entry_points('ravenml.plugins.data'))
-@data.group(help='Create a new dataset.')
+@data.group(cls=LazyPluginGroup, entry_point_name='ravenml.plugins.data', help='Create a new dataset.')
 def create():
     click.echo("Eventually this will create datasets for you.")
 

--- a/ravenml/train/commands.py
+++ b/ravenml/train/commands.py
@@ -18,6 +18,7 @@ from click_plugins import with_plugins
 from ravenml.train.interfaces import TrainInput, TrainOutput
 from ravenml.utils.question import cli_spinner
 from ravenml.utils.aws import upload_file_to_s3, upload_dict_to_s3_as_json
+from ravenml.utils.plugins import LazyPluginGroup
 
 EC2_INSTANCE_ID_URL = 'http://169.254.169.254/latest/meta-data/instance-id'
 
@@ -27,8 +28,7 @@ config_opt = click.option(
 )
 
 ### COMMANDS ###
-@with_plugins(iter_entry_points('ravenml.plugins.train'))
-@click.group(help='Training commands.')
+@click.group(cls=LazyPluginGroup, entry_point_name='ravenml.plugins.train', help='Training commands.')
 @click.pass_context
 @config_opt
 def train(ctx: click.Context, config: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click==7.0
-click-plugins==1.0.4
 questionary==1.0.2
 boto3==1.9.86
 shortuuid==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     download_url = 'https://github.com/autognc/ravenML/archive/v1.2.tar.gz',
     install_requires=[
         'Click>=7.0',
-        'click-plugins>=1.0.4',
         'questionary>=1.0.2',
         'boto3>=1.9.86', 
         'shortuuid>=0.5.0',


### PR DESCRIPTION
Waiting 5 seconds to run a base ravenml command sucks, but so does having to copy-and-paste dynamic_import into every single plugin. This implementation completely replaces `click-plugins` and doesn't load the plugin code until an actual plugin command is invoked, e.g. `ravenml train tf-keypoints`.

This also fixes the unintuitive behavior of `click-plugins` where if a plugin failed to load, your command would fail with the error `No such command tf-keypoints` and you would have to run `ravenml train tf_keypoints --help` to see what happened. Now, the command will just crash if it tries to load a bad plugin.

The only downside, as far as I can tell, is that the base group can no longer render the help text for each plugin subgroup. For example, if you ran `ravenml train` or `ravenml train --help`, the output used to look like: 

```
Usage: ravenml train [OPTIONS] COMMAND [ARGS]...

  Training commands.

Options:
  -c, --config TEXT  Path to config file. Defaults to
                     ~/ravenML_configs/config.yaml

  --help             Show this message and exit.

Commands:
  tf-keypoints  TensorFlow Keypoints Regression.
  tf-bbox          TensorFlow Bbox Detection.
```

Now, it looks like:
```
Usage: ravenml train [OPTIONS] COMMAND [ARGS]...

  Training commands.

Options:
  -c, --config TEXT  Path to config file. Defaults to
                     ~/ravenML_configs/config.yaml

  --help             Show this message and exit.

Commands:
  tf-keypoints
  tf-bbox
```

This is because the help text is defined inside the plugin code, so the plugin has to be imported before it can be accessed.