### PR TITLE
Add Support For Custom RavenML Storage Path

### DIFF
--- a/ravenml/utils/aws.py
+++ b/ravenml/utils/aws.py
@@ -48,8 +48,8 @@ def download_prefix(bucket_name: str, prefix: str, cache: RMLCache, custom_path:
             local_path = cache.path / custom_path / prefix
         else:
             local_path = cache.path / prefix
-
-        subprocess.call(["aws", "s3", "sync", s3_uri, local_path, '--quiet'])
+            
+        subprocess.call(["aws", "s3", "sync", s3_uri, str(local_path), '--quiet'])
         return True
     except:
         return False

--- a/ravenml/utils/aws.py
+++ b/ravenml/utils/aws.py
@@ -48,7 +48,7 @@ def download_prefix(bucket_name: str, prefix: str, cache: RMLCache, custom_path:
             local_path = cache.path / custom_path / prefix
         else:
             local_path = cache.path / prefix
-            
+
         subprocess.call(["aws", "s3", "sync", s3_uri, str(local_path), '--quiet'])
         return True
     except:

--- a/ravenml/utils/local_cache.py
+++ b/ravenml/utils/local_cache.py
@@ -9,8 +9,10 @@ import os
 import shutil
 from pathlib import Path
 
+
 # local cache root path for ravenml application
-RAVENML_LOCAL_STORAGE_PATH = Path(os.path.expanduser('~/.ravenML'))
+RAVENML_LOCAL_STORAGE_PATH = Path(os.environ.get("RAVENML_STORAGE_PATH", os.path.expanduser('~/.ravenML')))
+
 
 class RMLCache(object):
     """Represents a local storage cache. Provides functions for
@@ -22,11 +24,8 @@ class RMLCache(object):
     Attributes:
         path (Path): Absolute path in filesystem to root of the local cache.
     """
-
-    # local cache root path for ravenml application
-    RAVENML_LOCAL_STORAGE_PATH = Path(os.path.expanduser('~/.ravenML'))
     
-    def __init__(self, path:str='.'):
+    def __init__(self, path: str='.'):
         self.path = RAVENML_LOCAL_STORAGE_PATH / Path(path)
         # self.ensure_exists()
 


### PR DESCRIPTION
Adds `RAVENML_STORAGE_PATH` that when exists replaces the default `~/.ravenML`.

This should be backward compatible.

This PR also fixes an issue w/calling aws cli where repr(path) was being passed rather than str(path), not sure how this hasn't come up before.