### PR TITLE
Allow partial download of imagesets

### DIFF
--- a/ravenml/data/commands.py
+++ b/ravenml/data/commands.py
@@ -10,7 +10,6 @@ import pydoc
 import yaml
 import shutil
 from pkg_resources import iter_entry_points
-from click_plugins import with_plugins
 from colorama import Fore
 from pathlib import Path
 from ravenml.utils.imageset import get_imageset_names, get_imageset_metadata

--- a/ravenml/data/helpers.py
+++ b/ravenml/data/helpers.py
@@ -296,7 +296,7 @@ def read_json_metadata(dir_entry, image_id):
         dataframe with image_id key and True/False values
         for each tag.
     """
-    with open(dir_entry.path, "r") as read_file:
+    with open(dir_entry, "r") as read_file:
         data = json.load(read_file)
     tag_list = data.get("tags", ['untagged'])
     if len(tag_list) == 0:

--- a/ravenml/data/interfaces.py
+++ b/ravenml/data/interfaces.py
@@ -10,6 +10,7 @@ import click
 import os
 import shutil
 import json
+import asyncio
 from pathlib import Path
 from datetime import datetime
 from ravenml.utils.local_cache import RMLCache
@@ -94,7 +95,16 @@ class CreateInput(object):
             ## Download imagesets
             self.imageset_cache.ensure_subpath_exists('imagesets')
             self.imageset_paths = []
-            self.download_imagesets(imageset_list)
+            if config.get("download_full_imagesets") and config["download_full_imagesets"]:
+                self.download_imagesets(imageset_list)
+                self.lazy_loading = False
+            else:
+                self.imageset_cache.ensure_subpath_exists('imagesets/')
+                for imageset in imageset_list:
+                    self.imageset_cache.ensure_subpath_exists(f'imagesets/{imageset}')
+                    self.imageset_paths.append(self.imageset_cache.path / 'imagesets' / imageset)
+                self.lazy_loading = True
+
         # local imagesets
         else:
             imageset_paths = config.get('imageset')

--- a/ravenml/data/write_dataset.py
+++ b/ravenml/data/write_dataset.py
@@ -262,7 +262,7 @@ class DefaultDatasetWriter(DatasetWriter):
                 imageset_to_image_ids_dict[os.path.basename(image_id[0])].append(image_id)
 
         for image_id in self.image_ids:
-            temp = read_json_metadata(image_id[0] / f'{image_id[1]}{self.metadata_format[1]}', image_id[1])
+            temp = read_json_metadata(image_id[0] / f'{self.metadata_format[0]}{image_id[1]}{self.metadata_format[1]}', image_id[1])
             self.tags_df = pd.concat((self.tags_df, temp), sort=False)
         self.tags_df = self.tags_df.fillna(False)
         self.image_ids = default_filter(self.tags_df, self.filter_metadata)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ shortuuid==0.5.0
 halo==0.0.26
 colorama==0.3.9
 pyaml==19.4.1
+aiboto3==8.0.5


### PR DESCRIPTION
**Overview**
- Allows the option for partial download of imagesets rather than requiring full download \
- `download_full_imagesets` is a new optional parameter in config 
  - if set to true, behaves how it used to (all imagesets are fully downloaded into cache)
  - if set to false or not present, `setSizeFilter` must be set to values indicating how many images from each imageset are required
    - This is currently up to the plugin to check for and can be seen in the plugins repo

**Notes**
- The current implementation for asynchronous download may be done incorrectly or not as efficiently as possible,
  - I will work more on this by doing time testing
- This pull request goes along with the request in the ravenml-dataset-plugins repo 